### PR TITLE
Add support for windows runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,19 +6,24 @@ jobs:
     name: "Test getting latest CLI stable version"
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: Install 1Password CLI
         uses: ./ # 1password/install-cli-action@<version>
       - name: Check CLI version
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
         run: ./test/assert-version.sh latest
+      - name: Check CLI version
+        if: matrix.os == 'windows-latest'
+        run: .\test\assert-version.ps1 latest
+        shell: pwsh
   use-latest-beta-version:
     name: "Test getting latest CLI beta version"
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -27,12 +32,17 @@ jobs:
         with:
           version: latest-beta
       - name: Check CLI version
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
         run: ./test/assert-version.sh latest-beta
+      - name: Check CLI version
+        if: matrix.os == 'windows-latest'
+        run: .\test\assert-version.ps1 latest-beta
+        shell: pwsh
   use-specific-version:
     name: "Test getting a specific CLI version"
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -41,12 +51,17 @@ jobs:
         with:
           version: 2.18.0
       - name: Check CLI version
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
         run: ./test/assert-version.sh 2.18.0
+      - name: Check CLI version
+        if: matrix.os == 'windows-latest'
+        run: .\test\assert-version.ps1 2.18.0
+        shell: pwsh
   use-specific-beta-version:
     name: "Test getting a specific CLI beta version"
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -55,4 +70,9 @@ jobs:
         with:
           version: 2.19.0-beta.01
       - name: Check CLI version
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
         run: ./test/assert-version.sh 2.19.0-beta.01
+      - name: Check CLI version
+        if: matrix.os == 'windows-latest'
+        run: .\test\assert-version.ps1 2.19.0-beta.01
+        shell: pwsh

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install a specific version of the 1Password CLI:
 
 ## ⚙️ Supported Runners
 
-You can perform the action on Linux and macOS runners. Windows is not currently supported.
+You can perform the action on Linux, macOS and Windows runners.
 
 ## 💙 Community & Support
 

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,14 @@ runs:
   using: composite
   steps:
     - shell: bash
+      if : ${{ runner.os }} == 'Linux' || ${{ runner.os }} == 'macOS'
       env:
         OP_CLI_VERSION: ${{ inputs.version }}
       run: |
         ${{ github.action_path }}/install-cli.sh
+    - shell: pwsh
+      if : ${{ runner.os }} == 'Windows'
+      env:
+        OP_CLI_VERSION: ${{ inputs.version }}
+      run: |
+        ${{ github.action_path }}/install-cli.ps1

--- a/action.yml
+++ b/action.yml
@@ -12,14 +12,14 @@ runs:
   using: composite
   steps:
     - shell: bash
-      if : ${{ runner.os }} == 'Linux' || ${{ runner.os }} == 'macOS'
+      if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
       env:
         OP_CLI_VERSION: ${{ inputs.version }}
       run: |
         ${{ github.action_path }}/install-cli.sh
     - shell: pwsh
-      if : ${{ runner.os }} == 'Windows'
+      if: ${{ runner.os == 'Windows' }}
       env:
         OP_CLI_VERSION: ${{ inputs.version }}
       run: |
-        ${{ github.action_path }}/install-cli.ps1
+        ${{ github.action_path }}\install-cli.ps1

--- a/install-cli.ps1
+++ b/install-cli.ps1
@@ -66,5 +66,4 @@ if ($env:OP_CLI_VERSION -eq "latest") {
 } else {
     $OP_CLI_VERSION = "v$env:OP_CLI_VERSION"
 }
-$OP_CLI_VERSION
-#Install-OPCLI -OP_CLI_VERSION $OP_CLI_VERSION
+Install-OPCLI -OP_CLI_VERSION $OP_CLI_VERSION

--- a/install-cli.ps1
+++ b/install-cli.ps1
@@ -1,0 +1,70 @@
+$CLI_URL = "https://app-updates.agilebits.com/product_history/CLI2"
+
+# Fetch the latest version of 1Password CLI (on stable or beta channel)
+function Get-LatestCLIVersion {
+    param(
+        [string]$VersionType
+    )
+
+    $html = Invoke-WebRequest -Uri $CLI_URL
+
+    $version = $html.Content |
+        Select-String -Pattern '(?ms)<h3>(.*?)<\/h3>' -AllMatches |
+            ForEach-Object { $_.Matches } |
+                ForEach-Object { $_.Groups[1].Value } |
+                    ForEach-Object { $_ -replace '\s+', '' -replace '<span.*?>|<\/span>|&nbsp;.*', '' } |
+                        ForEach-Object {
+                            # If we're looking for the latest beta version, we need to print the first match whether it contains "beta" or not
+                            # If we're looking for the latest stable version, we need to print the first match that doesn't contain "beta"
+                            if (($VersionType -eq "beta") -or ($VersionType -eq "non_beta" -and $_ -notmatch "beta")) {
+                                $_
+                            }} |
+                            Select-Object -First 1
+
+    return "v$version"
+}
+
+# Install op-cli
+function Install-OPCLI {
+    param(
+        [string]$OP_CLI_VERSION
+    )
+
+    Write-Host "Installing 1Password CLI version: $OP_CLI_VERSION"
+
+    if ($IsWindows) {
+        # Get architecture
+        $WIN32_ARCH = (Get-CimInstance Win32_OperatingSystem).OSArchitecture
+        switch ($WIN32_ARCH) {
+            '64-bit' { $ARCH = 'amd64'; break }
+            '32-bit' { $ARCH = '386'; break }
+            Default { Write-Error "Sorry, your operating system architecture '$WIN32_ARCH' is unsupported" -ErrorAction Stop }
+        }
+        $URI="https://cache.agilebits.com/dist/1P/op2/pkg/$OP_CLI_VERSION/op_windows_${ARCH}_$OP_CLI_VERSION.zip"
+        Invoke-WebRequest -Uri $URI -OutFile op.zip
+        $installDir = Join-Path -Path $env:ProgramFiles -ChildPath '1Password CLI'
+        Expand-Archive -Path op.zip -DestinationPath $installDir -Force
+        $envMachinePath = [System.Environment]::GetEnvironmentVariable('PATH','machine')
+        if ($envMachinePath -split ';' -notcontains $installDir){
+            [Environment]::SetEnvironmentVariable('PATH', "$envMachinePath;$installDir", 'Machine')
+        }
+        Remove-Item -Path op.zip
+        Write-Output $installDir | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+    } else {
+        Write-Error "Install 1Password CLI GitHub Action isn't supported on this operating system using powershell."
+        exit 1
+    }
+
+}
+
+# Main action of the script
+
+if ($env:OP_CLI_VERSION -eq "latest") {
+    $OP_CLI_VERSION = Get-LatestCLIVersion -VersionType "non_beta"
+} elseif ($env:OP_CLI_VERSION -eq "latest-beta") {
+    $OP_CLI_VERSION = Get-LatestCLIVersion -VersionType "beta"
+} else {
+    $OP_CLI_VERSION = "v$env:OP_CLI_VERSION"
+}
+$OP_CLI_VERSION
+#Install-OPCLI -OP_CLI_VERSION $OP_CLI_VERSION

--- a/test/assert-version.ps1
+++ b/test/assert-version.ps1
@@ -1,0 +1,37 @@
+$OP_CLI_VERSION = $args[0]
+$CLI_URL = "https://app-updates.agilebits.com/product_history/CLI2"
+
+function Get-LatestCLIVersion {
+    param(
+        [string]$VersionType
+    )
+
+    $html = Invoke-WebRequest -Uri $CLI_URL
+
+    $version = $html.Content |
+        Select-String -Pattern '(?ms)<h3>(.*?)<\/h3>' -AllMatches |
+            ForEach-Object { $_.Matches } |
+                ForEach-Object { $_.Groups[1].Value } |
+                    ForEach-Object { $_ -replace '\s+', '' -replace '<span.*?>|<\/span>|&nbsp;.*', '' } |
+                        ForEach-Object {
+                            # If we're looking for the latest beta version, we need to print the first match whether it contains "beta" or not
+                            # If we're looking for the latest stable version, we need to print the first match that doesn't contain "beta"
+                            if (($VersionType -eq "beta") -or ($VersionType -eq "non_beta" -and $_ -notmatch "beta")) {
+                                $_
+                            }} |
+                            Select-Object -First 1
+
+    return $version
+}
+
+if ($OP_CLI_VERSION -eq "latest") {
+    $OP_CLI_VERSION = Get-LatestCliVersion -VersionType "non_beta"
+}
+elseif ($OP_CLI_VERSION -eq "latest-beta") {
+    $OP_CLI_VERSION = Get-LatestCliVersion -VersionType "beta"
+}
+
+if ((op --version) -ne $OP_CLI_VERSION) {
+    Write-Output "Expected CLI version to be:`n$OP_CLI_VERSION`nBut got:`n$(op --version)"
+    exit 1
+}


### PR DESCRIPTION
This PR adds support for running the action on windows runners. It includes:
- powershell script to install op, following the same logic as the original shell script
- powershell test script modelled after the original bash version
- changes to the .yml files to run the powershell script when running on windows
- updated README