### PR TITLE
Prepare v2 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "install-cli-action",
-	"version": "1.0.0",
+	"version": "2.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "install-cli-action",
-			"version": "1.0.0",
+			"version": "2.0.0",
 			"license": "MIT",
 			"dependencies": {
 				"@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "install-cli-action",
-	"version": "1.0.0",
+	"version": "2.0.0",
 	"description": "Install 1Password CLI into your GitHub Actions jobs",
 	"main": "dist/index.js",
 	"type": "module",


### PR DESCRIPTION
As implementation is compleatly changed and now action uses Typescript and Node.js instead of bash script, bumping next version to `v2` instead of `v1.1.0`.