### PR TITLE
Prepare release v2.0.2

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -32824,7 +32824,7 @@ var external_util_ = __nccwpck_require__(9023);
 
 
 
-const execAsync = (0,external_util_.promisify)(external_child_process_.exec);
+const execFileAsync = (0,external_util_.promisify)(external_child_process_.execFile);
 class MacOsInstaller extends CliInstaller {
     platform = "darwin"; // Node.js platform identifier for macOS
     constructor(version) {
@@ -32841,7 +32841,7 @@ class MacOsInstaller extends CliInstaller {
         const pkgWithExtension = `${pkgPath}.pkg`;
         external_fs_.renameSync(pkgPath, pkgWithExtension);
         const expandDir = "temp-pkg";
-        await execAsync(`pkgutil --expand "${pkgWithExtension}" "${expandDir}"`);
+        await execFileAsync("pkgutil", ["--expand", pkgWithExtension, expandDir]);
         const payloadPath = external_path_.join(expandDir, "op.pkg", "Payload");
         console.info("Installing 1Password CLI");
         const cliPath = await tool_cache.extractTar(payloadPath);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "install-cli-action",
-	"version": "2.0.1",
+	"version": "2.0.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "install-cli-action",
-			"version": "2.0.1",
+			"version": "2.0.2",
 			"license": "MIT",
 			"dependencies": {
 				"@actions/core": "^1.11.1",
@@ -148,7 +148,6 @@
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
 			"integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
 				"@babel/code-frame": "^7.27.1",
@@ -1601,7 +1600,6 @@
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.38.0.tgz",
 			"integrity": "sha512-Zhy8HCvBUEfBECzIl1PKqF4p11+d0aUJS1GeUiuqK9WmOug8YCmC4h4bjyBvMyAMI9sbRczmrYL5lKg/YMbrcQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.38.0",
 				"@typescript-eslint/types": "8.38.0",
@@ -2086,7 +2084,6 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -2544,7 +2541,6 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
-			"peer": true,
 			"dependencies": {
 				"caniuse-lite": "^1.0.30001726",
 				"electron-to-chromium": "^1.5.173",
@@ -3389,7 +3385,6 @@
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.31.0.tgz",
 			"integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -5105,7 +5100,6 @@
 			"resolved": "https://registry.npmjs.org/jest/-/jest-30.0.4.tgz",
 			"integrity": "sha512-9QE0RS4WwTj/TtTC4h/eFVmFAhGNVerSB9XpJh8sqaXlP73ILcPcZ7JWjjEtJJe2m8QyBLKKfPQuK+3F+Xij/g==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@jest/core": "30.0.4",
 				"@jest/types": "30.0.1",
@@ -7992,7 +7986,6 @@
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
 			"integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
 			"dev": true,
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "install-cli-action",
-	"version": "2.0.1",
+	"version": "2.0.2",
 	"description": "Install 1Password CLI into your GitHub Actions jobs",
 	"main": "dist/index.js",
 	"type": "module",


### PR DESCRIPTION
## Fixes
- `op-cli-installer` dependency is removed https://github.com/1Password/install-cli-action/pull/25

## Security
- Bumps [glob](https://github.com/isaacs/node-glob) from 10.4.5 to 10.5.0. https://github.com/1Password/install-cli-action/pull/26
- Bumps [js-yaml](https://github.com/nodeca/js-yaml) from 3.14.1 to 3.14.2. https://github.com/1Password/install-cli-action/pull/27