### PR TITLE
Bump actions/checkout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install 1Password CLI
         uses: ./ # 1password/install-cli-action@<version>
       - name: Check CLI version
@@ -21,7 +21,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install 1Password CLI
         uses: ./ # 1password/install-cli-action@<version>
         with:
@@ -35,7 +35,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install 1Password CLI
         uses: ./ # 1password/install-cli-action@<version>
         with:
@@ -49,7 +49,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install 1Password CLI
         uses: ./ # 1password/install-cli-action@<version>
         with:


### PR DESCRIPTION
Node 20 is reaching EOL. This PR updates actions/checkout v6 to use version with Node 24 ([v5 ](https://github.com/actions/checkout/releases/tag/v5.0.0)has the node changes)

Can see warnings removed here: https://github.com/1Password/install-cli-action/actions/runs/23508718533?pr=33