### PR TITLE
Prepare Release v3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ To install the latest version of the 1Password CLI: \
 
 ```yaml
 - name: Install 1Password CLI
-  uses: 1password/install-cli-action@v2
+  uses: 1password/install-cli-action@v3
 ```
 
 To install the latest beta version (i.e. `latest-beta`) of the 1Password CLI:
 
 ```yaml
 - name: Install 1Password CLI
-  uses: 1password/install-cli-action@v2
+  uses: 1password/install-cli-action@v3
   with:
     version: latest-beta
 ```
@@ -34,7 +34,7 @@ To install a specific version of the 1Password CLI:
 
 ```yaml
 - name: Install 1Password CLI
-  uses: 1password/install-cli-action@v2
+  uses: 1password/install-cli-action@v3
   with:
     version: 2.31.1
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "install-cli-action",
-	"version": "2.0.2",
+	"version": "3.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "install-cli-action",
-			"version": "2.0.2",
+			"version": "3.0.0",
 			"license": "MIT",
 			"dependencies": {
 				"@actions/core": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "install-cli-action",
-	"version": "2.0.2",
+	"version": "3.0.0",
 	"description": "Install 1Password CLI into your GitHub Actions jobs",
 	"main": "dist/index.js",
 	"type": "module",


### PR DESCRIPTION
Release PR for v 3.0.0

## What's Changed

## Fix
- Action now runs on Node 24 instead of Node 20. {#30}
- Update the Developer Slack link in README.md. {#29}
- Bump `actions/checkout` to v6 so workflows use the current Node runtime and avoid Node 20 deprecation warnings. {#33}

## Security
- Resolve Dependabot/npm audit issues, upgraded @actions/core and @actions/tool-cache. {#32}

Note for reviewer: ran `npm run build` but latest build is already in main.