### PR TITLE
Prepare release v4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ---
 
-*This project is licensed under [MIT](./LICENSE). Use of the 1Password APIs and services accessed through these tools is governed by the [1Password API Terms of Service](https://1password.com/legal/api-sdk-terms-of-service).*
+_This project is licensed under [MIT](./LICENSE). Use of the 1Password APIs and services accessed through these tools is governed by the [1Password API Terms of Service](https://1password.com/legal/api-sdk-terms-of-service)._
 
 # ✨ Quickstart
 
@@ -20,14 +20,14 @@ To install the latest version of the 1Password CLI: \
 
 ```yaml
 - name: Install 1Password CLI
-  uses: 1password/install-cli-action@v3
+  uses: 1password/install-cli-action@v4
 ```
 
 To install the latest beta version (i.e. `latest-beta`) of the 1Password CLI:
 
 ```yaml
 - name: Install 1Password CLI
-  uses: 1password/install-cli-action@v3
+  uses: 1password/install-cli-action@v4
   with:
     version: latest-beta
 ```
@@ -36,7 +36,7 @@ To install a specific version of the 1Password CLI:
 
 ```yaml
 - name: Install 1Password CLI
-  uses: 1password/install-cli-action@v3
+  uses: 1password/install-cli-action@v4
   with:
     version: 2.31.1
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "install-cli-action",
-	"version": "3.0.0",
+	"version": "4.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "install-cli-action",
-			"version": "3.0.0",
+			"version": "4.0.0",
 			"license": "MIT",
 			"dependencies": {
 				"@actions/core": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "install-cli-action",
-	"version": "3.0.0",
+	"version": "4.0.0",
 	"description": "Install 1Password CLI into your GitHub Actions jobs",
 	"main": "dist/index.js",
 	"type": "module",


### PR DESCRIPTION
## What's Changed

## Breaking changes

- Install now fails if CLI signature verification fails. ([#37](https://github.com/1Password/install-cli-action/pull/37))
- Linux self-hosted runners must have `gpg` available on PATH. ([#37](https://github.com/1Password/install-cli-action/pull/37))

## Security
- Verify 1Password CLI signatures on install for Linux, macOS, and Windows before adding the binary to PATH. ([#37](https://github.com/1Password/install-cli-action/pull/37))


### Documentation
- README now includes a notice that 1Password API usage is governed by the [1Password API Terms of Service](https://1password.com/legal/api-sdk-terms-of-service). ([#39](https://github.com/1Password/install-cli-action/pull/39))

⚠️ MAJOR update as this requires linux self-hosted runners to have gpg available.